### PR TITLE
feat: add 2025 publications

### DIFF
--- a/src/views/Agency/components/Goby/Goby.js
+++ b/src/views/Agency/components/Goby/Goby.js
@@ -17,6 +17,40 @@ const Goby = () => {
   // Complete publication data
   const publications = [
     {
+      title:
+        'Violated predictions enhance the representational fidelity of visual features in perception (2025, Journal of Vision)',
+      authors:
+        'Reuben Rideaux, Phuong Dang, Liam Jackel-David, Dragan Rangelov and Jason B. Mattingley',
+      url: 'https://doi.org/10.1101/2024.03.27.587109',
+      description:
+        'The study shows that when sensory predictions are violated, visual feature representations become sharper, suggesting expectation errors refine perceptual coding.',
+    },
+    {
+      title:
+        'The influence of temporal context on vision over multiple time scales (2025, eLife)',
+      authors: 'Kyungkoo Lee and Reuben Rideaux',
+      url: 'https://doi.org/10.7554/eLife.106614',
+      description:
+        'This article demonstrates how visual perception is shaped by temporal context spanning from milliseconds to minutes, revealing adaptive mechanisms across multiple timescales.',
+    },
+    {
+      title:
+        'Distinct neurochemical predictors for different phases of decision-making learning (2025, Cerebral Cortex)',
+      authors:
+        'Molly Gordon, Shane E. Ehrhardt, Reuben Rideaux, Małgorzata Marjańska, Dinesh Deelchand, Zahra Eftekhari, Paul E. Dux and Hannah L. Filmer',
+      url: 'https://doi.org/10.1093/cercor/bhaf144',
+      description:
+        'Using magnetic resonance spectroscopy, the authors identify separate neurochemical markers that forecast early acquisition and later consolidation during decision-making training.',
+    },
+    {
+      title:
+        'Multimodal evidence challenges the effectiveness of probabilistic cueing for establishing sensory expectations (2025, Imaging Neuroscience)',
+      authors: 'Zhicheng Hu, Duy Tran and Reuben Rideaux',
+      url: 'https://doi.org/10.1101/2025.03.22.644773',
+      description:
+        'Across behavioral and neuroimaging measures, the authors find limited support for probabilistic cueing as a mechanism to set sensory expectations.',
+    },
+    {
       title: 'Inverted encoding of neural responses to audiovisual stimuli reveals super-additive multisensory enhancement (2024, eLife)',
       authors: 'Zak Buhmann, Amanda K Robinson, Jason B Mattingley and Reuben Rideaux',
       url: 'https://doi.org/10.7554/eLife.97230.2',

--- a/src/views/Agency/components/Larq/Larq.js
+++ b/src/views/Agency/components/Larq/Larq.js
@@ -17,6 +17,14 @@ const Larq = () => {
   // Complete publication data
   const publications = [
     {
+      title:
+        'Reply to: “Model mimicry limits conclusions about neural tuning and can mistakenly imply unlikely priors” (2025, Nature Communications)',
+      authors: 'Reuben Rideaux, Paul M. Bays and William J. Harrison',
+      url: 'https://doi.org/10.1038/s41467-025-60860-9',
+      description:
+        'This commentary addresses concerns about model mimicry in neural tuning studies, clarifying how assumptions about priors influence interpretations of sensory coding.',
+    },
+    {
       title: 'Neurochemical Predictors of Generalized Learning Induced by Brain Stimulation and Training (2024, Journal of Neuroscience)',
       authors: 'Shane E. Ehrhardt, Yohan Wards, Reuben Rideaux, Małgorzata Marjańska, Jin Jin, Martijn A. Cloos, Dinesh K. Deelchand, Helge J. Zöllner, Muhammad G. Saleh, Steve C. N. Hui, Tonima Ali, Thomas B. Shaw, Markus Barth, Jason B. Mattingley, Hannah L. Filmer and Paul E. Dux',
       url: 'https://www.jneurosci.org/content/44/21/e1676232024',

--- a/src/views/Agency/components/Nike/Nike.js
+++ b/src/views/Agency/components/Nike/Nike.js
@@ -17,6 +17,14 @@ const Nike = () => {
   // Complete publication data
   const publications = [
     {
+      title:
+        'Energy efficiency and sensitivity benefits in a motion processing adaptive recurrent neural network (2025, Neural Networks)',
+      authors: 'Vishal Mohan and Reuben Rideaux',
+      url: 'https://doi.org/10.1016/j.neunet.2025.107834',
+      description:
+        'The paper introduces an adaptive recurrent neural network for motion processing that achieves greater sensitivity while reducing energy consumption compared to static models.',
+    },
+    {
       title: 'Task-related modulation of event-related potentials does not reflect changes to sensory representations (2024, Journal of Vision)',
       authors: 'Reuben Rideaux',
       url: 'https://doi.org/10.1162/imag_a_00266',


### PR DESCRIPTION
## Summary
- add 2025 studies on prediction errors, temporal context, neurochemical learning markers and probabilistic cueing to sensory integration category
- note commentary on model mimicry in neurochemistry category
- include energy-efficient motion network study in methods development category

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aee3f2ad7c832085711a86482bcc6d