### PR TITLE
Update branding to use LAB logo assets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="/assets/rideauxlab_logo.png" />
+    <link rel="shortcut icon" href="/assets/LAB_LOGO.png" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
@@ -20,7 +20,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:image"
-      content="/assets/rideauxlab_logo.png"
+      content="/assets/LAB_LOGO.png"
     />
     <meta
       property="og:title"

--- a/src/demos/ecommerce/layouts/Main/components/Footer/Footer.js
+++ b/src/demos/ecommerce/layouts/Main/components/Footer/Footer.js
@@ -31,8 +31,8 @@ const Footer = () => {
               component={'img'}
               src={
                 mode === 'light'
-                  ? 'https://assets.maccarianagency.com/the-front/logos/logo.svg'
-                  : 'https://assets.maccarianagency.com/the-front/logos/logo-negative.svg'
+                  ? '/LAB_LOGO.svg'
+                  : '/LAB_LOGO.svg'
               }
               height={1}
               width={1}

--- a/src/demos/ecommerce/layouts/Main/components/Topbar/Topbar.js
+++ b/src/demos/ecommerce/layouts/Main/components/Topbar/Topbar.js
@@ -30,8 +30,8 @@ const Topbar = ({ handleMobileMenuClick, pages = [] }) => {
           component={'img'}
           src={
             mode === 'light'
-              ? 'https://assets.maccarianagency.com/the-front/logos/logo.svg'
-              : 'https://assets.maccarianagency.com/the-front/logos/logo-negative.svg'
+              ? '/LAB_LOGO.svg'
+              : '/LAB_LOGO.svg'
           }
           height={1}
           width={1}

--- a/src/layouts/Fixed/components/Footer/Footer.js
+++ b/src/layouts/Fixed/components/Footer/Footer.js
@@ -31,8 +31,8 @@ const Footer = () => {
               component={'img'}
               src={
                 mode === 'light'
-                  ? 'https://assets.maccarianagency.com/the-front/logos/logo.svg'
-                  : 'https://assets.maccarianagency.com/the-front/logos/logo-negative.svg'
+                  ? '/LAB_LOGO.svg'
+                  : '/LAB_LOGO.svg'
               }
               height={1}
               width={1}

--- a/src/layouts/Fixed/components/Topbar/Topbar.js
+++ b/src/layouts/Fixed/components/Topbar/Topbar.js
@@ -30,8 +30,8 @@ const Topbar = ({ onSidebarOpen }) => {
           component={'img'}
           src={
             mode === 'light'
-              ? 'https://assets.maccarianagency.com/the-front/logos/logo.svg'
-              : 'https://assets.maccarianagency.com/the-front/logos/logo-negative.svg'
+              ? '/LAB_LOGO.svg'
+              : '/LAB_LOGO.svg'
           }
           height={1}
           width={1}

--- a/src/layouts/Fluid/Fluid.js
+++ b/src/layouts/Fluid/Fluid.js
@@ -75,8 +75,8 @@ const Fluid = ({
                 component={'img'}
                 src={
                   mode === 'light' && !colorInvert
-                    ? 'https://assets.maccarianagency.com/the-front/logos/logo.svg'
-                    : 'https://assets.maccarianagency.com/the-front/logos/logo-negative.svg'
+                    ? '/LAB_LOGO.svg'
+                    : '/LAB_LOGO.svg'
                 }
                 height={1}
                 width={1}

--- a/src/layouts/Fluid/components/Footer/Footer.js
+++ b/src/layouts/Fluid/components/Footer/Footer.js
@@ -31,8 +31,8 @@ const Footer = () => {
               component={'img'}
               src={
                 mode === 'light'
-                  ? 'https://assets.maccarianagency.com/the-front/logos/logo.svg'
-                  : 'https://assets.maccarianagency.com/the-front/logos/logo-negative.svg'
+                  ? '/LAB_LOGO.svg'
+                  : '/LAB_LOGO.svg'
               }
               height={1}
               width={1}

--- a/src/layouts/Main/components/Footer/Footer.js
+++ b/src/layouts/Main/components/Footer/Footer.js
@@ -31,8 +31,8 @@ const Footer = () => {
               component={'img'}
               src={
                 mode === 'light'
-                  ? '/rideauxlab_logo.svg'
-                  : '/rideauxlab_logo.svg'
+                  ? '/LAB_LOGO.svg'
+                  : '/LAB_LOGO.svg'
               }
               height={1}
               width={1}

--- a/src/layouts/Main/components/Sidebar/components/SidebarNav/SidebarNav.js
+++ b/src/layouts/Main/components/Sidebar/components/SidebarNav/SidebarNav.js
@@ -34,8 +34,8 @@ const SidebarNav = ({ pages, colorInvert = false }) => {
           component={'img'}
           src={
             mode === 'light' && !colorInvert
-              ? '/rideauxlab_logo.svg'
-              : '/rideauxlab_logo.svg'
+              ? '/LAB_LOGO.svg'
+              : '/LAB_LOGO.svg'
           }
           height={1}
           width={1}

--- a/src/layouts/Main/components/Topbar/Topbar.js
+++ b/src/layouts/Main/components/Topbar/Topbar.js
@@ -40,8 +40,8 @@ const Topbar = ({ onSidebarOpen, pages, colorInvert = false }) => {
           component={'img'}
           src={
             mode === 'light' && !colorInvert
-              ? '/rideauxlab_logo.svg'
-              : '/rideauxlab_logo.svg'
+              ? '/LAB_LOGO.svg'
+              : '/LAB_LOGO.svg'
           }
           height={1}
           width={1}

--- a/src/views/IndexView/IndexView.js
+++ b/src/views/IndexView/IndexView.js
@@ -102,7 +102,7 @@ const IndexView = () => {
           height: '100%',
           zIndex: 0,                // keep it behind text but above <body> background
           pointerEvents: 'none',    // ignore mouse events
-          backgroundImage: 'url("/assets/rideauxlab_logo.png")',
+          backgroundImage: 'url("/assets/LAB_LOGO.png")',
           backgroundRepeat: 'repeat',
           backgroundSize: '200px 200px',
           backgroundPosition: '0 0',


### PR DESCRIPTION
## Summary
- replace header, footer, and sidebar logo references with the new `/LAB_LOGO.svg` asset across layouts
- update favicon and hero background imagery to point at `/assets/LAB_LOGO.png` for consistent branding

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dde53150ec8320b6177a45150c26c0