### PR TITLE
Simplify grants display on funding section

### DIFF
--- a/src/views/Agency/components/GrantsDisplay/GrantsDisplay.js
+++ b/src/views/Agency/components/GrantsDisplay/GrantsDisplay.js
@@ -5,12 +5,8 @@ import {
   // eslint-disable-next-line no-unused-vars
   Typography,
   useTheme,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Divider,
+  Paper,
 } from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Award } from 'lucide-react';
 
 const GrantsDisplay = () => {
@@ -173,67 +169,54 @@ const GrantsDisplay = () => {
         Funding
       </Typography>
 
-      <Box width="100%" maxWidth={900}>
+      <Box width="100%" maxWidth={900} display="flex" flexDirection="column" gap={2}>
         {grants.map((grant) => (
-          <Accordion
+          <Paper
             key={grant.id}
+            elevation={0}
             sx={{
               borderRadius: 2,
-              marginBottom: 2,
-              overflow: 'hidden',
+              padding: 2,
               border: `1px solid ${
                 theme.palette.mode === 'dark' ? '#444' : '#ccc'
               }`,
+              backgroundColor: theme.palette.background.paper,
             }}
           >
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Box
+              display="flex"
+              flexDirection={{ xs: 'column', sm: 'row' }}
+              alignItems={{ xs: 'flex-start', sm: 'center' }}
+              gap={2}
+            >
               <Box
-                display="flex"
-                flexDirection={{ xs: 'column', sm: 'row' }}
-                alignItems="center"
-                gap={2}
-                width="100%"
-              >
-                <Box
-                  component="img"
-                  src={grant.logo}
-                  alt={`${grant.organization} logo`}
-                  sx={{
-                    width: 60,
-                    height: 'auto',
-                    filter:
-                      theme.palette.mode === 'dark'
-                        ? 'brightness(0) invert(0.7)'
-                        : 'none',
-                  }}
-                />
+                component="img"
+                src={grant.logo}
+                alt={`${grant.organization} logo`}
+                sx={{
+                  width: 60,
+                  height: 'auto',
+                  filter:
+                    theme.palette.mode === 'dark'
+                      ? 'brightness(0) invert(0.7)'
+                      : 'none',
+                }}
+              />
 
-                <Box display="flex" flexDirection="column" flexGrow={1} gap={0.5}>
-                  {/* Row with an Award icon + date */}
-                  <Box display="flex" alignItems="center" gap={1}>
-                    <Award size={20} className="text-yellow-500" />
-                    <Typography variant="subtitle2" color="text.secondary">
-                      {grant.dateRange}
-                    </Typography>
-                  </Box>
-
-                  <Typography variant="h6" sx={{ fontWeight: 600 }}>
-                    {grant.organization}
-                  </Typography>
-                  <Typography variant="body1" color="text.primary">
-                    {grant.title}
+              <Box display="flex" flexDirection="column" gap={0.5}>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Award size={20} className="text-yellow-500" />
+                  <Typography variant="subtitle2" color="text.secondary">
+                    {grant.dateRange}
                   </Typography>
                 </Box>
-              </Box>
-            </AccordionSummary>
 
-            <AccordionDetails>
-              <Divider sx={{ my: 2 }} />
-              <Typography variant="body2" color="text.secondary">
-                {grant.additionalInfo || 'No additional details provided.'}
-              </Typography>
-            </AccordionDetails>
-          </Accordion>
+                <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                  {grant.organization}
+                </Typography>
+              </Box>
+            </Box>
+          </Paper>
         ))}
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- replace the accordion list of grants with a simple paper card layout
- show only the grant logo, year range, and name while hiding subheadings and descriptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddfe7f60fc832084f8f21af3efa443