### PR TITLE
Add new sensory integration publications

### DIFF
--- a/src/views/Agency/components/Goby/Goby.js
+++ b/src/views/Agency/components/Goby/Goby.js
@@ -18,6 +18,22 @@ const Goby = () => {
   const publications = [
     {
       title:
+        'Investigating orientation adaptation following naturalistic film viewing (2025, Scientific Reports)',
+      authors: 'Amine I-Izzeddin, Reuben Rideaux, Jason B. Mattingley and William J. Harrison',
+      url: 'https://www.nature.com/srep/',
+      description:
+        'Orientation-selective adaptation is a cornerstone of visual processing, yet it remains unclear how it manifests during complex, naturalistic experiences. This study examines how prolonged exposure to oriented content within films shapes subsequent perceptual sensitivity, revealing robust adaptation effects that persist beyond the laboratory and highlighting the ecological relevance of orientation-tuned mechanisms...',
+    },
+    {
+      title:
+        'Reply to: “Model mimicry limits conclusions about neural tuning and can mistakenly imply unlikely priors” (2025, Nature Communications)',
+      authors: 'Reuben Rideaux, Paul M. Bays & William J. Harrison',
+      url: 'https://doi.org/10.1038/s41467-025-60860-9',
+      description:
+        'A key goal of visual neuroscience is to understand how the physical properties of the world are represented by the brain. Efficient coding theory states that neural resources allocated to coding environmental features should be proportional to the frequency with which those features are found in nature. We recently found a horizontal bias in the neural representation of visual orientation, as measured in humans with electroencephalography...',
+    },
+    {
+      title:
         'Violated predictions enhance the representational fidelity of visual features in perception (2025, Journal of Vision)',
       authors:
         'Reuben Rideaux, Phuong Dang, Luke Jackel-David, Zak Buhmann, Dragan Rangelov and Jason B. Mattingley',

--- a/src/views/Agency/components/Larq/Larq.js
+++ b/src/views/Agency/components/Larq/Larq.js
@@ -17,14 +17,6 @@ const Larq = () => {
   // Complete publication data
   const publications = [
     {
-      title:
-        'Reply to: “Model mimicry limits conclusions about neural tuning and can mistakenly imply unlikely priors” (2025, Nature Communications)',
-      authors: 'Reuben Rideaux, Paul M. Bays & William J. Harrison',
-      url: 'https://doi.org/10.1038/s41467-025-60860-9',
-      description:
-        'A key goal of visual neuroscience is to understand how the physical properties of the world are represented by the brain. Efficient coding theory1,2 states that neural resources allocated to coding environmental features should be proportional to the frequency with which those features are found in nature. We recently found3 a horizontal bias in the neural representation of visual orientation, as measured in humans with electroencephalography (EEG)...',
-    },
-    {
       title: 'Neurochemical Predictors of Generalized Learning Induced by Brain Stimulation and Training (2024, Journal of Neuroscience)',
       authors: 'Shane E. Ehrhardt, Yohan Wards, Reuben Rideaux, Małgorzata Marjańska, Jin Jin, Martijn A. Cloos, Dinesh K. Deelchand, Helge J. Zöllner, Muhammad G. Saleh, Steve C. N. Hui, Tonima Ali, Thomas B. Shaw, Markus Barth, Jason B. Mattingley, Hannah L. Filmer and Paul E. Dux',
       url: 'https://www.jneurosci.org/content/44/21/e1676232024',


### PR DESCRIPTION
## Summary
- add the 2025 Scientific Reports paper on naturalistic orientation adaptation to the sensory integration publications list
- move the 2025 Nature Communications reply on neural tuning expectations into the sensory integration stream from the neurochemistry stream

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de01a5b560832091918d32ab1fd342