### PR TITLE
Use dark logo asset in dark mode

### DIFF
--- a/src/demos/ecommerce/layouts/Main/components/Footer/Footer.js
+++ b/src/demos/ecommerce/layouts/Main/components/Footer/Footer.js
@@ -32,7 +32,7 @@ const Footer = () => {
               src={
                 mode === 'light'
                   ? '/assets/LAB_LOGO.png'
-                  : '/assets/LAB_LOGO.png'
+                  : '/assets/LAB_LOGO_dark.png'
               }
               height={1}
               width={1}

--- a/src/demos/ecommerce/layouts/Main/components/Topbar/Topbar.js
+++ b/src/demos/ecommerce/layouts/Main/components/Topbar/Topbar.js
@@ -31,7 +31,7 @@ const Topbar = ({ handleMobileMenuClick, pages = [] }) => {
           src={
             mode === 'light'
               ? '/assets/LAB_LOGO.png'
-              : '/assets/LAB_LOGO.png'
+              : '/assets/LAB_LOGO_dark.png'
           }
           height={1}
           width={1}

--- a/src/layouts/Fixed/components/Footer/Footer.js
+++ b/src/layouts/Fixed/components/Footer/Footer.js
@@ -32,7 +32,7 @@ const Footer = () => {
               src={
                 mode === 'light'
                   ? '/assets/LAB_LOGO.png'
-                  : '/assets/LAB_LOGO.png'
+                  : '/assets/LAB_LOGO_dark.png'
               }
               height={1}
               width={1}

--- a/src/layouts/Fixed/components/Topbar/Topbar.js
+++ b/src/layouts/Fixed/components/Topbar/Topbar.js
@@ -31,7 +31,7 @@ const Topbar = ({ onSidebarOpen }) => {
           src={
             mode === 'light'
               ? '/assets/LAB_LOGO.png'
-              : '/assets/LAB_LOGO.png'
+              : '/assets/LAB_LOGO_dark.png'
           }
           height={1}
           width={1}

--- a/src/layouts/Fluid/Fluid.js
+++ b/src/layouts/Fluid/Fluid.js
@@ -76,7 +76,7 @@ const Fluid = ({
                 src={
                   mode === 'light' && !colorInvert
                     ? '/assets/LAB_LOGO.png'
-                    : '/assets/LAB_LOGO.png'
+                    : '/assets/LAB_LOGO_dark.png'
                 }
                 height={1}
                 width={1}

--- a/src/layouts/Fluid/components/Footer/Footer.js
+++ b/src/layouts/Fluid/components/Footer/Footer.js
@@ -32,7 +32,7 @@ const Footer = () => {
               src={
                 mode === 'light'
                   ? '/assets/LAB_LOGO.png'
-                  : '/assets/LAB_LOGO.png'
+                  : '/assets/LAB_LOGO_dark.png'
               }
               height={1}
               width={1}

--- a/src/layouts/Main/components/Footer/Footer.js
+++ b/src/layouts/Main/components/Footer/Footer.js
@@ -32,7 +32,7 @@ const Footer = () => {
               src={
                 mode === 'light'
                   ? '/assets/LAB_LOGO.png'
-                  : '/assets/LAB_LOGO.png'
+                  : '/assets/LAB_LOGO_dark.png'
               }
               height={1}
               width={1}

--- a/src/layouts/Main/components/Sidebar/components/SidebarNav/SidebarNav.js
+++ b/src/layouts/Main/components/Sidebar/components/SidebarNav/SidebarNav.js
@@ -35,7 +35,7 @@ const SidebarNav = ({ pages, colorInvert = false }) => {
           src={
             mode === 'light' && !colorInvert
               ? '/assets/LAB_LOGO.png'
-              : '/assets/LAB_LOGO.png'
+              : '/assets/LAB_LOGO_dark.png'
           }
           height={1}
           width={1}

--- a/src/layouts/Main/components/Topbar/Topbar.js
+++ b/src/layouts/Main/components/Topbar/Topbar.js
@@ -41,7 +41,7 @@ const Topbar = ({ onSidebarOpen, pages, colorInvert = false }) => {
           src={
             mode === 'light' && !colorInvert
               ? '/assets/LAB_LOGO.png'
-              : '/assets/LAB_LOGO.png'
+              : '/assets/LAB_LOGO_dark.png'
           }
           height={1}
           width={1}

--- a/src/views/IndexView/IndexView.js
+++ b/src/views/IndexView/IndexView.js
@@ -102,7 +102,10 @@ const IndexView = () => {
           height: '100%',
           zIndex: 0,                // keep it behind text but above <body> background
           pointerEvents: 'none',    // ignore mouse events
-          backgroundImage: 'url("/assets/LAB_LOGO.png")',
+          backgroundImage:
+            theme.palette.mode === 'dark'
+              ? 'url("/assets/LAB_LOGO_dark.png")'
+              : 'url("/assets/LAB_LOGO.png")',
           backgroundRepeat: 'repeat',
           backgroundSize: '200px 200px',
           backgroundPosition: '0 0',


### PR DESCRIPTION
## Summary
- update all layout navigation elements to render LAB_LOGO_dark.png when the theme is in dark mode
- adjust the animated background in the Index view to use the dark logo asset for dark mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e09814cf788320bbe94e38748a251d