### PR TITLE
Align contact form email flow with career forms

### DIFF
--- a/src/views/ContactPageSidebarMap/components/Form/Form.js
+++ b/src/views/ContactPageSidebarMap/components/Form/Form.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unescaped-entities */
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 import Box from '@mui/material/Box';
@@ -13,6 +13,9 @@ import Alert from '@mui/material/Alert';
 import emailjs from '@emailjs/browser';
 
 import Container from 'components/Container'; // Adjust this import if needed
+
+// Initialize EmailJS with your public key (done once at module scope)
+emailjs.init('tCN1dFcOBCtCrk491');
 
 // ------------------- 1) Validation Schema -------------------
 const validationSchema = yup.object({
@@ -28,7 +31,7 @@ const validationSchema = yup.object({
     .min(2, 'Please enter a valid name')
     .max(50, 'Please enter a valid name')
     .required('Please specify your last name'),
-  email: yup
+  from_email: yup
     .string()
     .trim()
     .email('Please enter a valid email address')
@@ -43,23 +46,20 @@ const validationSchema = yup.object({
 const Contact = () => {
   const theme = useTheme();
 
-  // -------------- A) Submission Alert State --------------
+  // -------------- A) Form reference and submission alert state --------------
+  const formRef = useRef(null);
   const [submitStatus, setSubmitStatus] = useState({
     show: false,
     success: false,
     message: '',
   });
 
-  // -------------- B) Initialize EmailJS --------------
-  // If you prefer, you can place this in a useEffect or in a separate file.
-  emailjs.init('tCN1dFcOBCtCrk491'); // <-- Replace with your actual Public Key
-
   // ------------------- 3) Left Side (Form) -------------------
   const LeftSide = () => {
     const initialValues = {
       firstName: '',
       lastName: '',
-      email: '',
+      from_email: '',
       message: '',
     };
 
@@ -73,20 +73,12 @@ const Contact = () => {
           message: 'Sending message...',
         });
 
-        // Build the template parameters (match with your EmailJS template)
-        const templateParams = {
-          from_name: `${values.firstName} ${values.lastName}`,
-          from_email: values.email,
-          message: values.message,
-          // You can add more fields if your EmailJS template has them
-          // e.g. to_name, phone, etc.
-        };
-
-        // Send email with EmailJS
-        const response = await emailjs.send(
-          'service_6q1p18j',      // <-- Replace with your actual service ID
-          'template_j2kjadd',    // <-- Replace with your actual template ID
-          templateParams
+        // Send the form to EmailJS using the DOM reference
+        const response = await emailjs.sendForm(
+          'service_6q1p18j',
+          'template_j2kjadd',
+          formRef.current,
+          'tCN1dFcOBCtCrk491'
         );
 
         // Check response status
@@ -154,7 +146,7 @@ const Contact = () => {
 
         {/* Our contact form */}
         <Box>
-          <form noValidate onSubmit={formik.handleSubmit}>
+          <form noValidate ref={formRef} onSubmit={formik.handleSubmit}>
             <Grid container spacing={4}>
               {/* First Name */}
               <Grid item xs={12} sm={6}>
@@ -205,12 +197,16 @@ const Contact = () => {
                   variant="outlined"
                   color="primary"
                   size="medium"
-                  name="email"
+                  name="from_email"
                   fullWidth
-                  value={formik.values.email}
+                  value={formik.values.from_email}
                   onChange={formik.handleChange}
-                  error={formik.touched.email && Boolean(formik.errors.email)}
-                  helperText={formik.touched.email && formik.errors.email}
+                  error={
+                    formik.touched.from_email && Boolean(formik.errors.from_email)
+                  }
+                  helperText={
+                    formik.touched.from_email && formik.errors.from_email
+                  }
                 />
               </Grid>
 
@@ -233,6 +229,13 @@ const Contact = () => {
                   helperText={formik.touched.message && formik.errors.message}
                 />
               </Grid>
+
+              {/* Hidden combined name for EmailJS template */}
+              <input
+                type="hidden"
+                name="from_name"
+                value={`${formik.values.firstName} ${formik.values.lastName}`.trim()}
+              />
 
               {/* Submit Button */}
               <Grid item xs={12}>


### PR DESCRIPTION
## Summary
- initialize EmailJS once at module scope for the contact form
- switch contact form submission to use emailjs.sendForm with a DOM ref
- ensure template fields (from_name/from_email/message) are supplied via form inputs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942867133f08320a751495a9aa3ab75)